### PR TITLE
Redirecting HTTP to HTTPS using gin secure middleware

### DIFF
--- a/build_deploy_docker.bat
+++ b/build_deploy_docker.bat
@@ -1,7 +1,6 @@
 ::Build statically-linked binary for alpine linux
 set GOOS=linux
 set GOARCH=amd64
-set GIN_MODE=debug
 go build -o alpine_binary .
 
 deploy_docker.bat

--- a/build_deploy_docker.bat
+++ b/build_deploy_docker.bat
@@ -1,6 +1,7 @@
 ::Build statically-linked binary for alpine linux
 set GOOS=linux
 set GOARCH=amd64
+set GIN_MODE=debug
 go build -o alpine_binary .
 
 deploy_docker.bat

--- a/controller/routing.go
+++ b/controller/routing.go
@@ -20,7 +20,7 @@ func Route() {
 	router := gin.Default()
 
 	router.LoadHTMLGlob("templates/*.tmpl")
-	router.Static("/static", "static")
+	router.Static("/static", "./static")
 
 	//TODO: Split into routing groups
 	router.GET("/", func(c *gin.Context) {

--- a/controller/routing.go
+++ b/controller/routing.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/gin-gonic/contrib/secure"
 	"github.com/gin-gonic/gin"
 )
 
@@ -18,6 +19,19 @@ func Route() {
 
 	//Set up routing
 	router := gin.Default()
+
+	//Redirect to HTTPS when not in debug mode
+	router.Use(
+		secure.Secure(secure.Options{
+			SSLRedirect:          true,
+			SSLProxyHeaders:      map[string]string{"X-Forwarded-Proto": "https"},
+			STSSeconds:           315360000,
+			STSIncludeSubdomains: true,
+			FrameDeny:            true,
+			ContentTypeNosniff:   true,
+			BrowserXssFilter:     true,
+			IsDevelopment:        gin.IsDebugging(),
+		}))
 
 	router.LoadHTMLGlob("templates/*.tmpl")
 	router.Static("/static", "./static")

--- a/deploy_docker.bat
+++ b/deploy_docker.bat
@@ -1,3 +1,3 @@
 ::Build Docker image to container and run it
 docker build -t fantasy_image .
-docker run --rm -it --env-file .env --publish 8080:8080 --name fantasy-container fantasy_image
+docker run --rm -it --env-file .env -e "GIN_MODE=debug" --publish 8080:8080 --name fantasy-container fantasy_image


### PR DESCRIPTION
Heroku provides SSL by default if you use one of their subdomains.
